### PR TITLE
Update for Grails 2.4.0

### DIFF
--- a/NavigationGrailsPlugin.groovy
+++ b/NavigationGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class NavigationGrailsPlugin {
-    def version = '1.4.0'
+    def version = '1.4.0-SNAPSHOT'
 
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.4 > *"

--- a/NavigationGrailsPlugin.groovy
+++ b/NavigationGrailsPlugin.groovy
@@ -1,8 +1,8 @@
 class NavigationGrailsPlugin {
-    def version = '1.3.2'
+    def version = '1.4.0'
 
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "1.2 > *"
+    def grailsVersion = "2.4 > *"
 
     def dependsOn = [controllers:"1.0 > *"]
     def observe = ['controllers']

--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,4 @@
 #Grails Metadata file
 #Fri Jul 29 12:57:45 BST 2011
-app.grails.version=1.3.7
+app.grails.version=2.4.0
 app.name=Navigation
-plugins.hibernate=1.3.7
-plugins.tomcat=1.3.7

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Fri Jul 29 12:57:45 BST 2011
-app.grails.version=2.4.0
+app.grails.version=2.4.2
 app.name=Navigation

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,0 +1,26 @@
+
+grails.project.work.dir = "target"
+grails.project.fork = false
+
+grails.project.dependency.resolver = "maven"
+grails.project.dependency.resolution = {
+
+    inherits("global")
+
+    repositories {
+        grailsCentral()
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
+
+        // runtime 'mysql:mysql-connector-java:5.1.5'
+    }
+
+    plugins {
+        build ':release:3.0.1', {
+            export = false
+        }
+    }
+}

--- a/grails-app/services/NavigationService.groovy
+++ b/grails-app/services/NavigationService.groovy
@@ -1,5 +1,5 @@
 import org.codehaus.groovy.grails.commons.GrailsControllerClass
-import grails.util.Holder
+import grails.util.Holders
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
 
 // @todo subItem sorting
@@ -15,7 +15,7 @@ class NavigationService {
     def reset() {
         byGroup = ['*':[]]
         // re-add the manually defined items
-        Holder.config.navigation?.each { k, v ->
+        Holders.config.navigation?.each { k, v ->
             doRegisterItem(k, v)
         }
         manuallyRegistered.each { item ->

--- a/grails-app/services/NavigationService.groovy
+++ b/grails-app/services/NavigationService.groovy
@@ -1,5 +1,5 @@
 import org.codehaus.groovy.grails.commons.GrailsControllerClass
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holder
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
 
 // @todo subItem sorting
@@ -15,7 +15,7 @@ class NavigationService {
     def reset() {
         byGroup = ['*':[]]
         // re-add the manually defined items
-        ConfigurationHolder.config.navigation?.each { k, v ->
+        Holder.config.navigation?.each { k, v ->
             doRegisterItem(k, v)
         }
         manuallyRegistered.each { item ->


### PR DESCRIPTION
Update removes the `ConfigurationHolder` class in favor of `Holders.config` to make it compatible with Grails 2.4.0.
